### PR TITLE
Use tree-sitter-language-pack instead of py-tree-sitter-languages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
     "watchdog",
     "ldap3",
     "textual[syntax]",
-    "tree-sitter-languages",
+    "tree-sitter-language-pack",
     "pyperclip",
     "qrcode",
     "tomli-w",

--- a/src/elva/widgets/textarea.py
+++ b/src/elva/widgets/textarea.py
@@ -18,7 +18,7 @@ from textual.geometry import Size
 from textual.strip import Strip
 from textual.widgets import TextArea
 from tree_sitter import Language, Node, Parser, Point, Query, Tree
-from tree_sitter_languages import get_language, get_parser
+from tree_sitter_language_pack import get_language, get_parser
 
 # TODO: Define these as methods of YTextArea when that is merged with YDocument
 # TODO: Use an Array[Text] Y data type to represent document contents


### PR DESCRIPTION
...py-tree-sitter-languages seems to be unmaintained. As a bonus the language packs are pre-compiled, so there's no need to compile anything on install - which would have failed on Windows